### PR TITLE
Implemented configure-ssh script to simplify SSH key configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,5 @@ RUN apt-get update && \
     apt-get upgrade -yy && \
     apt-get install -yy awscli ssh ftp rsync && \
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/* /usr/share/man
+
+ADD files /

--- a/files/usr/bin/configure-ssh
+++ b/files/usr/bin/configure-ssh
@@ -1,0 +1,10 @@
+#!/bin/sh -e
+[ -z "$SSH_PRIVATE_KEY" ] && echo "Need to set SSH_PRIVATE_KEY" && exit 1;
+[ -z "$DEPLOY_HOST" ] && echo "Need to set DEPLOY_HOST" && exit 1;
+[ -z "$DEPLOY_HOST_KEY" ] && echo "Need to set DEPLOY_HOST_KEY" && exit 1;
+
+# Install SSH private key and host key
+mkdir -m 0700 -p ~/.ssh
+echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
+echo "$DEPLOY_HOST $DEPLOY_HOST_KEY" > ~/.ssh/known_hosts
+chmod 0600 ~/.ssh/*


### PR DESCRIPTION
Adding SSH key configuration snippets to each `.gitlab-ci.yml` file is not very efficient. With this script you could just add `configure-ssh` command to your build pipeline.